### PR TITLE
Change filtering logic to avoid multiple-useEffects

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,62 +4,71 @@ import Header from "./components/Header";
 import Main from "./components/Main";
 import Footer from "./components/Footer";
 
+const SEARCH_PARAMS = ["title", "text"];
+
 function App() {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState("");
+
   const [items, setItems] = useState([]);
+  const [filteredItems, setFilteredItems] = useState([]);
+
   const [lang, setLang] = useState();
-  const [searchParam] = useState(["title", "text"]);
 
   const extractHashLang = () => {
     const { hash } = window.location;
-    let hashLang = hash.replace('#', '').slice(0, 2);
-    if (hashLang && (hashLang === 'en' || hashLang === 'ru')) {
+    let hashLang = hash.replace("#", "").slice(0, 2);
+    if (hashLang && (hashLang === "en" || hashLang === "ru")) {
       return hashLang;
     }
-    return '';
-  }
-
+    return "";
+  };
 
   useEffect(() => {
-    // console.log(extractHashLang());
-    let userLang = extractHashLang() || localStorage.getItem('lang') || navigator.language || navigator.userLanguage;
+    let userLang =
+      extractHashLang() ||
+      localStorage.getItem("lang") ||
+      navigator.language ||
+      navigator.userLanguage;
     setLang(userLang.slice(0, 2));
   }, []);
 
   // get data
   useEffect(() => {
     if (lang !== undefined) {
-      fetch(`https://raw.githubusercontent.com/roose/lor-poc-data/main/data-${lang}.json`)
-        .then(res => res.json())
-        .then(
-          (result) => {
-            result.sort((a, b) => {
-              return a.title > b.title;
-            });
-            setItems(result);
-          }
-        );
+      fetch(
+        `https://raw.githubusercontent.com/roose/lor-poc-data/main/data-${lang}.json`
+      )
+        .then((res) => res.json())
+        .then((result) => {
+          result.sort((a, b) => {
+            return a.title > b.title;
+          });
+          setItems(result);
+        });
     }
   }, [lang]);
 
-  // search by title & text
-  const search = (items) => {
-    return items.filter(item => {
-      return searchParam.some(newItem => {
-        return (
-          item[newItem]
-            .toString()
-            .toLowerCase()
-            .indexOf(query.toLowerCase()) > -1
-        );
-      });
-    });
-  }
+  useEffect(() => {
+    const filteredItems = query
+      ? items.filter((item) => {
+          return SEARCH_PARAMS.some((searchParam) => {
+            return (
+              item[searchParam]
+                .toString()
+                .toLowerCase()
+                .indexOf(query.toLowerCase()) > -1
+            );
+          });
+        })
+      : items;
+
+    setFilteredItems(filteredItems);
+  }, [items, query]);
 
   return (
     <div className="App">
       <Header query={query} setQuery={setQuery} lang={lang} setLang={setLang} />
-      <Main search={search} items={items} lang={lang} />
+      <Main items={filteredItems} lang={lang} />
       <Footer lang={lang} />
     </div>
   );

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,16 +1,23 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Node from "./Node";
 
-const Main = ({ search, items, lang }) => {
+const Main = ({ items, lang }) => {
 
   const base_url = 'https://dd.b.pvp.net/latest';
   const apiLang = lang === 'en' ? 'en_us' : 'ru_ru';
   const lab_url = `https://raw.githubusercontent.com/roose/lor-poc-data/main/data/lab/${apiLang}/img/cards`;
 
+  useEffect(() => {
+    const { hash } = window.location;
+    const id = hash.replace('#', '');
+    const element = document.getElementById(id);
+    if (element) element.scrollIntoView();
+  }, [items]);
+
   return (
     <main className="main">
       <ul className="main_items">
-        {search(items).map((item, id) => (
+        {items.map((item, id) => (
           <Node key={id} {...item} apiLang={apiLang} lang={lang} base_url={base_url} lab_url={lab_url} />
         ))}
       </ul>

--- a/src/components/Node.jsx
+++ b/src/components/Node.jsx
@@ -1,15 +1,8 @@
-import React, { useEffect } from "react";
+import React from "react";
 import slugify from "slugify";
 
 const Node = ({title, text, cards, lang, apiLang, base_url, lab_url}) => {
   const slug = slugify(title, {lower: true});
-
-  useEffect(() => {
-    const { hash } = window.location;
-    const id = hash.replace('#', '');
-    const element = document.getElementById(id);
-    if (element) element.scrollIntoView();
-  }, [])
 
   return (
     <li className="main_item">


### PR DESCRIPTION
## What

- Add additional `state` for filtered items, to avoid filter results dynamic recalculations
- Wrap filtering in `useEffect` to automatically filter based on `query`
- Extract scrolling `useEffect` from Node level to Main level, to call useEffect less amount of times

## Why

- Minor performance optimizations, to avoid dynamic recalculations and unnecessary calls for useEffect